### PR TITLE
Refactor renderer to use preload API

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,14 +40,12 @@
 </head>
 <body>
     <script>
-        const { ipcRenderer } = require('electron');
-
         async function loadTiles() {
-            const services = await ipcRenderer.invoke('get-sorted-services');
+            const services = await window.electronAPI.getSortedServices();
             for (const service of services) {
                 const tile = document.createElement('div');
                 tile.className = 'tile';
-                tile.onclick = () => ipcRenderer.send('launch-service', service);
+                tile.onclick = () => window.electronAPI.launchService(service);
 
                 const img = document.createElement('img');
                 img.src = `icons/${service.toLowerCase().replace(/[^a-z0-9]/g, '')}.png`;


### PR DESCRIPTION
## Summary
- remove direct require of `electron` in `index.html`
- call `window.electronAPI` functions for IPC
- keep preload.js exposing `launchService` and `getSortedServices`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e3cb748c832f9381e9bd5a076f12