### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Node modules
+node_modules/
+
+# Logs
+npm-debug.log*
+logs
+*.log
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.pid.lock
+
+# Coverage directory
+coverage/
+
+# Production build directory
+build/
+dist/
+
+# OS files
+.DS_Store
+
+# Environment files
+.env
+
+# Editor directories and files
+.idea/
+.vscode/


### PR DESCRIPTION
## Summary
- add .gitignore to keep node_modules and logs out of version control

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e74b9c78832f88a77633ef21e6f1