### PR TITLE
Add Jest tests and ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12
+  },
+  "rules": {}
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  env: {
+    node: true,
+    es2021: true,
+    jest: true
+  },
+  extends: 'eslint:recommended',
+  parserOptions: {
+    ecmaVersion: 12
+  },
+  rules: {}
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,17 @@
   "description": "Stream Deck Launcher for Steam Deck - Unified Streaming Dashboard",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "jest",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json ."
   },
   "author": "N47H4NI3L <74298967+n47h4ni3l@users.noreply.github.com>",
   "license": "MIT",
   "dependencies": {
     "electron": "^25.3.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "eslint": "^8.56.0"
   }
 }

--- a/tests/getSortedServices.test.js
+++ b/tests/getSortedServices.test.js
@@ -1,0 +1,16 @@
+const { getSortedServices, services } = require('../main');
+
+describe('getSortedServices', () => {
+  test('sorts services based on provided usage data', () => {
+    const usage = { Netflix: 3, Hulu: 1, Prime: 2 };
+    const sorted = getSortedServices(usage);
+    expect(sorted[0]).toBe('Netflix');
+    expect(sorted[1]).toBe('Prime');
+    expect(sorted[2]).toBe('Hulu');
+  });
+
+  test('returns all available services', () => {
+    const sorted = getSortedServices({});
+    expect(sorted.length).toBe(Object.keys(services).length);
+  });
+});


### PR DESCRIPTION
## Summary
- export `getSortedServices` safely
- add Jest test for sorted service order
- add Jest config
- set up ESLint with minimal rules
- update npm scripts for test and lint

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f4766f74832fbe948a79eaccd8b1