### PR TITLE
Add quick install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 Unified streaming dashboard for **Steam Deck** (and any Linux desktop).  
 Built with Electron — controller-friendly UI, persistent login, usage tracking, no-sleep.
 
+## Quick Install
+
+Run the installer script directly from GitHub:
+
+```bash
+wget https://raw.githubusercontent.com/n47h4ni3l/Stream-Deck/main/install.sh
+chmod +x install.sh
+./install.sh
+```
+
 ---
 
 ## Features


### PR DESCRIPTION
## Summary
- add a Quick Install section near the top of the README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fd46a0c0832fbb9a2a2011536989