### PR TITLE
Improve npx invocation in launcher

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -9,5 +9,15 @@ cd "$(dirname "$0")"
 # Make sure Chromium AppImage is executable
 chmod +x chromium/Chromium-x86-64.AppImage
 
+# Determine how to run npx
+if command -v npx >/dev/null 2>&1; then
+    NPX_CMD="npx"
+elif command -v flatpak >/dev/null 2>&1; then
+    NPX_CMD="flatpak run --command=npx org.nodejs.Node"
+else
+    echo "npx not found – install Node.js." >&2
+    exit 1
+fi
+
 # Run Electron app (fullscreen / Deck-friendly)
-npx electron . --enable-features=OverlayScrollbar --kiosk
+"$NPX_CMD" electron . --enable-features=OverlayScrollbar --kiosk


### PR DESCRIPTION
## Summary
- add detection logic for `npx` or `flatpak` npx
- use variable when launching electron

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68440d9b693c832fa0afe246a420ac4a