### PR TITLE
Fix Node flatpak install remote check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,9 @@ fi
 # Install Node via Flatpak on Steam Deck if needed
 if [ "$NODE_FLATPAK" = true ]; then
     echo "Installing Node.js via Flatpak..."
+    if ! flatpak remotes --user | grep -q '^flathub\\>' ; then
+        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    fi
     flatpak install -y --user flathub org.nodejs.Node
     NPM_CMD="flatpak run --command=npm org.nodejs.Node"
 else


### PR DESCRIPTION
## Summary
- ensure the `flathub` remote exists before installing Node via flatpak

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440e72e2c8832f921ed9af70474aa1