### PR TITLE
Automatically handle pacman update failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to set up requirements and download Chromium:
+2. Run the installer script to set up requirements and download Chromium. If `pacman` fails to sync (common on SteamOS due to a read-only filesystem), the script now attempts to disable the read-only mode and retry automatically:
 
 ```bash
 ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,14 @@ fi
 if [ ${#packages[@]} -gt 0 ]; then
     echo "Installing packages: ${packages[*]}"
     if [ "$PM" = "pacman" ]; then
-        sudo pacman -Sy --needed --noconfirm "${packages[@]}"
+        if ! sudo pacman -Sy --needed --noconfirm "${packages[@]}"; then
+            echo "pacman failed to synchronize. Attempting to disable read-only filesystem..." >&2
+            if command -v steamos-readonly >/dev/null 2>&1; then
+                sudo steamos-readonly disable
+            fi
+            sudo pacman -Sy
+            sudo pacman -Sy --needed --noconfirm "${packages[@]}"
+        fi
     elif [ "$PM" = "apt" ]; then
         sudo apt-get update
         sudo apt-get install -y "${packages[@]}"


### PR DESCRIPTION
## Summary
- retry pacman installs when the first attempt fails
- clarify installer note in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config not supported in flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68440f375fa4832fb40d21ac3f407ad5