### PR TITLE
Handle unknown package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ cd Stream-Deck
 ```bash
 ./install.sh
 ```
+If the script reports **"No supported package manager found"**,
+install `git`, `nodejs` and `npm` manually using your package manager
+and then run `./install.sh` again.
 
 3. Launch Stream Deck:
 

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,10 @@ if [ ${#packages[@]} -gt 0 ]; then
         sudo apt-get install -y "${packages[@]}"
     elif [ "$PM" = "flatpak" ]; then
         echo "Flatpak detected -- skipping system package install"
+    else
+        echo "No supported package manager found."
+        echo "Please install: ${packages[*]} and re-run this script."
+        exit 1
     fi
 else
     echo "Required packages already installed."


### PR DESCRIPTION
## Summary
- warn and exit when the installer can't find pacman, apt, or flatpak
- document how to handle unsupported package managers

## Testing
- `npm test` *(fails: getPath undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684417a71bfc832f9b67ebd59b3c7dba