### PR TITLE
Fix tests to run without Electron app

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,7 +30,10 @@ const services = {
 };
 
 // Usage tracking file
-const usageFile = path.join(app.getPath('userData'), 'usage.json');
+const userDataPath = app && typeof app.getPath === 'function'
+  ? app.getPath('userData')
+  : __dirname;
+const usageFile = path.join(userDataPath, 'usage.json');
 let usageData = {};
 
 // Load usage data


### PR DESCRIPTION
## Summary
- ensure main.js gracefully handles missing Electron `app`
- update test workflow

## Testing
- `npm test`
- `npm run lint`
- `./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68441967d780832f9cbcce355264ad82