### PR TITLE
Update README for SteamOS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to set up requirements and download Chromium. If `pacman` fails to sync (common on SteamOS due to a read-only filesystem), the script now attempts to disable the read-only mode and retry automatically:
+2. Run the installer script to set up requirements and download Chromium. When SteamOS is detected the script installs Node via **Flatpak** and skips the read-only workaround. `pacman` is only used on other Arch-based systems where the script will disable read-only mode and retry if a sync fails:
 
 ```bash
 ./install.sh


### PR DESCRIPTION
## Summary
- document that `install.sh` installs Node via Flatpak on SteamOS
- clarify that `pacman` is only used for other Arch-based systems
- note that the read-only workaround is skipped on SteamOS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441e4722d0832f9f2a55058dcbe439