### PR TITLE
Improve launch error handling

### DIFF
--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -43,4 +43,13 @@ describe('launchService', () => {
     const data = JSON.parse(fs.readFileSync(usageFile));
     expect(data['Hulu']).toBe(1);
   });
+
+  test('handles spawn errors without throwing', () => {
+    const error = new Error('fail');
+    spawn.mockImplementation(() => { throw error; });
+    const event = { sender: { send: jest.fn() } };
+
+    expect(() => launchService('Netflix', event)).not.toThrow();
+    expect(event.sender.send).toHaveBeenCalledWith('launch-service-error', 'Netflix');
+  });
 });


### PR DESCRIPTION
## Summary
- catch Chromium spawn failures
- notify renderer about launch failure via IPC
- test that spawn errors do not crash

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68442907fc1c832f9c3de40b4e475f4f