### PR TITLE
Move electron to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,10 @@
   },
   "author": "N47H4NI3L <74298967+n47h4ni3l@users.noreply.github.com>",
   "license": "MIT",
-  "dependencies": {
-    "electron": "^25.3.1"
-  },
   "devDependencies": {
     "jest": "^29.7.0",
     "eslint": "^8.56.0",
-    "electron-builder": "^24.6.0"
+    "electron-builder": "^24.6.0",
+    "electron": "^25.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- move `electron` from `dependencies` to `devDependencies`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68442d6e8710832fb6ecb93404472dd5