### PR TITLE
Fix install script for SteamOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to set up requirements and download Chromium. When SteamOS is detected the script installs Node via **Flatpak** and skips the read-only workaround. `pacman` is only used on other Arch-based systems where the script will disable read-only mode and retry if a sync fails:
+2. Run the installer script to set up requirements and download Chromium. On SteamOS the script automatically disables the read-only filesystem and installs Node via **Flatpak**. `pacman` is only used on other Arch-based systems where the script will disable read-only mode and retry if a sync fails:
 
 ```bash
 ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,12 @@ if grep -qi "SteamOS" /etc/os-release 2>/dev/null; then
     IS_DECK=true
 fi
 
+# Disable read-only filesystem on SteamOS if possible
+if command -v steamos-readonly >/dev/null 2>&1; then
+    echo "Disabling SteamOS read-only mode..."
+    sudo steamos-readonly disable || true
+fi
+
 # Detect package manager
 if [ "$IS_DECK" = true ]; then
     PM="flatpak"


### PR DESCRIPTION
## Summary
- disable read-only filesystem on SteamOS before installing packages
- update docs for revised SteamOS behavior

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68442e2ca364832f86fc280575211953