### PR TITLE
Update installer to rely on flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to set up requirements and download Chromium. On SteamOS the script automatically disables the read-only filesystem and installs Node via **Flatpak**. `pacman` is only used on other Arch-based systems where the script will disable read-only mode and retry if a sync fails:
+2. Run the installer script to set up requirements and download Chromium. The script installs Node via **Flatpak** and handles the Steam Deck read-only filesystem automatically:
 
 ```bash
 ./install.sh


### PR DESCRIPTION
## Summary
- simplify the install script
- drop all pacman logic and always use flatpak for Node.js
- update README instructions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844315530bc832fa0594ef178801745