### PR TITLE
Switch to Ungoogled Chromium flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to set up requirements and download Chromium. The script installs Node via **Flatpak** and handles the Steam Deck read-only filesystem automatically:
+2. Run the installer script to install all requirements, including Node.js and **Ungoogled Chromium** via **Flatpak**. The script automatically handles the Steam Deck read-only filesystem:
 
 ```bash
 ./install.sh

--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Stream Deck Launcher Script - Final Version
-# Launches Electron app with bundled Chromium launcher support
+# Launches Electron app using Ungoogled Chromium Flatpak
 
 # Set working directory to script location
 cd "$(dirname "$0")"
 
-# Make sure Chromium AppImage is executable
-chmod +x chromium/Chromium-x86-64.AppImage
 
 # Determine how to run npx
 if command -v npx >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,10 @@ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flat
 echo "Installing Node.js (via Flatpak)..."
 flatpak install -y flathub io.nodejs.NodeJS
 
+# Install Ungoogled Chromium via Flatpak
+echo "Installing Ungoogled Chromium (via Flatpak)..."
+flatpak install -y flathub com.github.Eloston.UngoogledChromium
+
 # Clone repo
 echo "Cloning Stream Deck Launcher repo..."
 if [ -d Stream-Deck ]; then
@@ -35,14 +39,6 @@ cd Stream-Deck
 # Install dependencies via Flatpak Node.js
 echo "Running npm install (via Flatpak Node.js)..."
 flatpak run io.nodejs.NodeJS npm install
-
-# Make Chromium AppImage executable
-echo "Making Chromium executable..."
-if [ ! -f chromium/Chromium-x86-64.AppImage ]; then
-  echo "Chromium AppImage not found. Please place it in the 'chromium' directory." >&2
-  exit 1
-fi
-chmod +x chromium/Chromium-x86-64.AppImage
 
 # Launch Stream Deck
 echo "Launching Stream Deck Launcher..."

--- a/main.js
+++ b/main.js
@@ -3,8 +3,8 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-// Path to bundled Chromium AppImage
-const chromiumPath = path.join(__dirname, 'chromium/Chromium-x86-64.AppImage');
+// Flatpak command for Ungoogled Chromium
+const chromiumCommand = ['flatpak', 'run', 'com.github.Eloston.UngoogledChromium'];
 
 // No-sleep blocker
 let psbId = null;
@@ -68,7 +68,11 @@ function launchService(serviceName, event) {
     saveUsage();
 
     try {
-      const child = spawn(chromiumPath, [url], { detached: true, stdio: 'ignore' });
+      const child = spawn(
+        chromiumCommand[0],
+        [...chromiumCommand.slice(1), url],
+        { detached: true, stdio: 'ignore' }
+      );
       child.unref();
     } catch (err) {
       console.error('Failed to launch service:', err);
@@ -142,5 +146,5 @@ module.exports = {
   usageFile,
   usageData,
   launchService,
-  chromiumPath
+  chromiumCommand
 };

--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -18,7 +18,7 @@ jest.mock('child_process', () => {
   return { spawn };
 });
 
-const { launchService, services, usageData, usageFile, chromiumPath } = require('../main');
+const { launchService, services, usageData, usageFile, chromiumCommand } = require('../main');
 const { spawn } = require('child_process');
 
 afterEach(() => {
@@ -31,8 +31,8 @@ describe('launchService', () => {
   test('spawns chromium with correct URL', () => {
     launchService('Netflix');
     expect(spawn).toHaveBeenCalledWith(
-      chromiumPath,
-      [services['Netflix']],
+      chromiumCommand[0],
+      [...chromiumCommand.slice(1), services['Netflix']],
       { detached: true, stdio: 'ignore' }
     );
   });


### PR DESCRIPTION
## Summary
- install Ungoogled Chromium from Flathub and remove AppImage logic
- drop the old chromium folder
- launch the browser via `flatpak run`
- update tests for the new spawn command
- update README install instructions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443a25d424832fb2cbad899fa75eb0