### PR TITLE
Add safety flags to launcher script

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Stream Deck Launcher Script - Final Version
 # Launches Electron app using Ungoogled Chromium Flatpak


### PR DESCRIPTION
## Summary
- enable strict Bash options in `StreamDeckLauncher.sh`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444b5f2c80832fa60077be80e177df