### PR TITLE
Add onerror handler for service icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,10 @@
                 const img = document.createElement('img');
                 img.src = `icons/${service.toLowerCase().replace(/[^a-z0-9]/g, '')}.png`;
                 img.alt = service;
+                img.onerror = () => {
+                    img.remove();
+                    tile.textContent = service;
+                };
 
                 tile.appendChild(img);
                 document.body.appendChild(tile);


### PR DESCRIPTION
## Summary
- add fallback for icon loading failures in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444beae6a0832f8d0cb02ad107372c