### PR TITLE
Switch to user-level flatpak install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/n47h4ni3l/Stream-Deck.git
 cd Stream-Deck
 ```
 
-2. Run the installer script to install all requirements, including Node.js and **Ungoogled Chromium** via **Flatpak**. The script automatically handles the Steam Deck read-only filesystem:
+2. Run the installer script to install all requirements, including Node.js and **Ungoogled Chromium** via **Flatpak**. The script automatically handles the Steam Deck read-only filesystem and installs Flatpak packages in user mode, so it won't ask for a root password:
 
 ```bash
 ./install.sh

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ command -v curl >/dev/null 2>&1 || {
 
 # Add Flathub if not already present
 echo "Checking Flathub..."
-flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
 # Install Volta if needed and ensure it's on PATH
 if [ ! -d "$HOME/.volta" ]; then
@@ -55,7 +55,7 @@ fi
 
 # Install Ungoogled Chromium via Flatpak
 echo "Installing Ungoogled Chromium (via Flatpak)..."
-flatpak install -y --system flathub com.github.Eloston.UngoogledChromium
+flatpak install -y --user flathub com.github.Eloston.UngoogledChromium
 
 # Clone repo
 echo "Cloning Stream Deck Launcher repo..."


### PR DESCRIPTION
## Summary
- use `--user` with flatpak remote-add and install in the installer
- document rootless install behaviour in README

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684456236b50832fb26f9cc5f95421f7