### PR TITLE
Update Ungoogled Chromium Flatpak ID

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ fi
 
 # Install Ungoogled Chromium via Flatpak
 echo "Installing Ungoogled Chromium (via Flatpak)..."
-flatpak install -y --system flathub com.github.Eloston.UngoogledChromium
+flatpak install -y --system flathub io.github.ungoogled_software.ungoogled_chromium
 
 # Clone repo
 echo "Cloning Stream Deck Launcher repo..."

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 // Flatpak command for Ungoogled Chromium
-const defaultChromiumCommand = ['flatpak', 'run', 'com.github.Eloston.UngoogledChromium'];
+const defaultChromiumCommand = ['flatpak', 'run', 'io.github.ungoogled_software.ungoogled_chromium'];
 const chromiumCommand = process.env.CHROMIUM_CMD
   ? process.env.CHROMIUM_CMD.split(/\s+/)
   : defaultChromiumCommand;


### PR DESCRIPTION
## Summary
- update deprecated Flatpak app ID in `install.sh`
- update Chromium default command in `main.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844563941b0832f99f55121b93a9ad5