### PR TITLE
Improve install.sh repo detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ dependencies and then launches the Stream Deck Launcher.
 ## Installation & Running
 **QUICK INSTALL (Steam Deck & Linux)**
 
-1. Clone Stream Deck Launcher:
+1. Clone Stream Deck Launcher (optional, the installer clones automatically if
+   run outside the repo):
 
 ```bash
 git clone https://github.com/n47h4ni3l/Stream-Deck.git
@@ -53,9 +54,10 @@ cd Stream-Deck
 ```bash
 ./install.sh
 ```
-If the script reports **"No supported package manager found"**,
-install `git`, `nodejs` and `npm` manually using your package manager
-and then run `./install.sh` again.
+The script detects if it's already running from within the repository and skips
+cloning automatically. If it reports **"No supported package manager found"**, 
+install `git`, `nodejs` and `npm` manually using your package manager and then
+run `./install.sh` again.
 
 3. Launch Stream Deck:
 

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,17 @@ command -v curl >/dev/null 2>&1 || {
   exit 1
 }
 
+# Detect if we're already inside the repo
+in_repo=0
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  repo_root="$(git rev-parse --show-toplevel)"
+  if [ -f "$repo_root/package.json" ]; then
+    echo "Detected existing Stream Deck repository at $repo_root"
+    cd "$repo_root"
+    in_repo=1
+  fi
+fi
+
 # Add Flathub if not already present
 echo "Checking Flathub..."
 flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
@@ -57,14 +68,18 @@ fi
 echo "Installing Ungoogled Chromium (via Flatpak)..."
 flatpak install -y --system flathub com.github.Eloston.UngoogledChromium
 
-# Clone repo
-echo "Cloning Stream Deck Launcher repo..."
-if [ -d Stream-Deck ]; then
-  echo "Directory 'Stream-Deck' already exists, skipping clone."
+# Clone repo if needed
+if [ "$in_repo" -eq 0 ]; then
+  echo "Cloning Stream Deck Launcher repo..."
+  if [ -d Stream-Deck ]; then
+    echo "Directory 'Stream-Deck' already exists, skipping clone."
+  else
+    git clone https://github.com/n47h4ni3l/Stream-Deck.git
+  fi
+  cd Stream-Deck
 else
-  git clone https://github.com/n47h4ni3l/Stream-Deck.git
+  echo "Using existing repository, skipping clone."
 fi
-cd Stream-Deck
 
 # Install dependencies using the Volta-managed npm
 echo "Running npm install..."


### PR DESCRIPTION
## Summary
- detect if `install.sh` is run inside the repo
- skip clone/cd when inside repo
- document the new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684456566f10832fac774c30fb904ed8