### PR TITLE
Update Electron to 29.4.0 LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "electron": "^25.3.1",
+        "electron": "^29.4.0",
         "electron-builder": "^24.6.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0"
@@ -1884,13 +1884,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/plist": {
@@ -3531,15 +3531,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.9.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.9.8.tgz",
-      "integrity": "sha512-PGgp6PH46QVENHuAHc2NT1Su8Q1qov7qIl2jI5tsDpTibwV2zD8539AeWBQySeBU4dhbj9onIl7+1bXQ0wefBg==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.6.tgz",
+      "integrity": "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^20.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -7767,9 +7767,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "jest": "^29.7.0",
     "eslint": "^8.56.0",
     "electron-builder": "^24.6.0",
-    "electron": "^25.3.1"
+    "electron": "^29.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump Electron to `^29.4.0`
- regenerate `package-lock.json`

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684456662104832fbd6f65fd5cb8d3bd