### PR TITLE
Update Flatpak ID for Ungoogled Chromium

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ fi
 
 # Install Ungoogled Chromium via Flatpak
 echo "Installing Ungoogled Chromium (via Flatpak)..."
-flatpak install -y --user flathub com.github.Eloston.UngoogledChromium
+flatpak install -y --user flathub io.github.ungoogled_software.ungoogled_chromium
 
 # Clone repo if needed
 if [ "$in_repo" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- update `install.sh` to use new Flatpak app ID for Ungoogled Chromium

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_684459b084dc832fa1e47da6107f0d50