### PR TITLE
Improve installer security

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,17 @@ Built with Electron — controller-friendly UI, persistent login, usage tracking
 
 ## Quick Install
 
-Install in one step using `curl`:
+Download and verify the installer script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/n47h4ni3l/Stream-Deck/main/install.sh | bash
+curl -fsSL -o /tmp/stream-deck-install.sh \
+  https://raw.githubusercontent.com/n47h4ni3l/Stream-Deck/main/install.sh
+echo "5d2e4465cccfe651c4689c19f15082867f0af35214ff8883b18bcf3498ed0e5f  /tmp/stream-deck-install.sh" | sha256sum -c -
+bash /tmp/stream-deck-install.sh
 ```
 
-This command pipes the script directly to bash, which installs all required
-dependencies and then launches the Stream Deck Launcher.
+The checksum check ensures the script has not been tampered with before it
+installs dependencies and launches the Stream Deck Launcher.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,14 @@ flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flath
 # Install Volta if needed and ensure it's on PATH
 if [ ! -d "$HOME/.volta" ]; then
   echo "Installing Volta..."
-  curl https://get.volta.sh | bash
+  tmp_volta_installer="$(mktemp)"
+  # Download installer instead of piping directly to bash so we can verify it
+  curl -fsSL https://get.volta.sh -o "$tmp_volta_installer"
+  # Verify installer integrity via SHA256 to ensure it hasn't been tampered with.
+  # Maintainers: update the expected hash if the upstream installer changes.
+  echo "fbdc4b8cb33fb6d19e5f07b22423265943d34e7e5c3d5a1efcecc9621854f9cb  $tmp_volta_installer" | sha256sum -c -
+  bash "$tmp_volta_installer"
+  rm -f "$tmp_volta_installer"
 else
   echo "Volta already installed."
 fi


### PR DESCRIPTION
## Summary
- use a temporary file when fetching Volta's installer and verify its SHA256
- update README quick install instructions to download, verify, and run installer

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68445c3beb80832fb9a516300e56895a