### PR TITLE
Fix launchService usage counting

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,22 +66,24 @@ function saveUsage() {
 // Launch a service URL in Chromium and track usage
 function launchService(serviceName, event) {
   const url = services[serviceName];
-  if (url) {
+  if (!url) {
+    return;
+  }
+
+  try {
+    const child = spawn(
+      chromiumCommand[0],
+      [...chromiumCommand.slice(1), url],
+      { detached: true, stdio: 'ignore' }
+    );
+    child.unref();
+
     usageData[serviceName] = (usageData[serviceName] || 0) + 1;
     saveUsage();
-
-    try {
-      const child = spawn(
-        chromiumCommand[0],
-        [...chromiumCommand.slice(1), url],
-        { detached: true, stdio: 'ignore' }
-      );
-      child.unref();
-    } catch (err) {
-      console.error('Failed to launch service:', err);
-      if (event && event.sender && typeof event.sender.send === 'function') {
-        event.sender.send('launch-service-error', serviceName);
-      }
+  } catch (err) {
+    console.error('Failed to launch service:', err);
+    if (event && event.sender && typeof event.sender.send === 'function') {
+      event.sender.send('launch-service-error', serviceName);
     }
   }
 }

--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -52,6 +52,8 @@ describe('launchService', () => {
 
     expect(() => launchService('Netflix', event)).not.toThrow();
     expect(event.sender.send).toHaveBeenCalledWith('launch-service-error', 'Netflix');
+    expect(usageData['Netflix']).toBeUndefined();
+    expect(fs.existsSync(usageFile)).toBe(false);
   });
 
   test('uses CHROMIUM_CMD environment variable when set', () => {


### PR DESCRIPTION
## Summary
- update usage counter increment after successful spawn
- ensure errors don't increment usage
- test error path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445c4c6130832f85e170ba78b45e58