### PR TITLE
Update default Chromium command and tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 // Flatpak command for Ungoogled Chromium
-const defaultChromiumCommand = ['flatpak', 'run', 'com.github.Eloston.UngoogledChromium'];
+const defaultChromiumCommand = ['flatpak', 'run', 'io.github.ungoogled_software.ungoogled_chromium'];
 const chromiumCommand = process.env.CHROMIUM_CMD
   ? process.env.CHROMIUM_CMD.split(/\s+/)
   : defaultChromiumCommand;

--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -74,4 +74,17 @@ describe('launchService', () => {
 
     delete process.env.CHROMIUM_CMD;
   });
+
+  test('uses default chromium command when CHROMIUM_CMD is unset', () => {
+    jest.resetModules();
+    delete process.env.CHROMIUM_CMD;
+
+    const { chromiumCommand } = require('../main');
+
+    expect(chromiumCommand).toEqual([
+      'flatpak',
+      'run',
+      'io.github.ungoogled_software.ungoogled_chromium'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- update the default Chromium flatpak path
- test default command when `CHROMIUM_CMD` isn't set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446ac549ac832f923e2bfdab5b2189