### PR TITLE
Update install to expand HOME in desktop entry

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,9 +94,10 @@ echo "Installing desktop shortcut..."
 
 desktop_file_target="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 
-echo "Copying StreamDeckLauncher.desktop to $desktop_file_target..."
+echo "Creating desktop file at $desktop_file_target..."
 mkdir -p "$(dirname "$desktop_file_target")"
-cp StreamDeckLauncher.desktop "$desktop_file_target"
+# Expand $HOME to an absolute path for Exec, Path and Icon entries
+envsubst < StreamDeckLauncher.desktop > "$desktop_file_target"
 
 chmod +x "$desktop_file_target"
 


### PR DESCRIPTION
## Summary
- ensure installation expands `$HOME` paths in StreamDeckLauncher.desktop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684472eb3aa8832f9a038163e3c904bc