### PR TITLE
Fix desktop path in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,9 @@ if [ "$in_repo" -eq 0 ]; then
   cd Stream-Deck
 fi
 
+# Remember where the repository lives so we can update the desktop file later
+install_dir="$(pwd)"
+
 # Ensure required commands are available
 command -v flatpak >/dev/null 2>&1 || {
   echo "flatpak is required but not installed. Aborting." >&2
@@ -92,11 +95,13 @@ chmod +x StreamDeckLauncher.sh
 # Install .desktop shortcut
 echo "Installing desktop shortcut..."
 
+
 desktop_file_target="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 
 echo "Copying StreamDeckLauncher.desktop to $desktop_file_target..."
 mkdir -p "$(dirname "$desktop_file_target")"
-cp StreamDeckLauncher.desktop "$desktop_file_target"
+# Replace the placeholder path in the .desktop file with the actual install directory
+sed "s|\\$HOME/Stream-Deck|$install_dir|g" StreamDeckLauncher.desktop > "$desktop_file_target"
 
 chmod +x "$desktop_file_target"
 


### PR DESCRIPTION
## Summary
- preserve the install directory when cloning or running inside the repo
- substitute the placeholder in `StreamDeckLauncher.desktop` before copying

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684472ed9114832fa79b9dfe0da4eff5