### PR TITLE
Apply dynamic desktop path fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,9 @@ if [ "$in_repo" -eq 0 ]; then
   cd Stream-Deck
 fi
 
+# Remember where the repository lives so we can update the desktop file later
+install_dir="$(pwd)"
+
 # Ensure required commands are available
 command -v flatpak >/dev/null 2>&1 || {
   echo "flatpak is required but not installed. Aborting." >&2
@@ -94,10 +97,11 @@ echo "Installing desktop shortcut..."
 
 desktop_file_target="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 
-echo "Creating desktop file at $desktop_file_target..."
+echo "Copying StreamDeckLauncher.desktop to $desktop_file_target..."
 mkdir -p "$(dirname "$desktop_file_target")"
-# Expand $HOME to an absolute path for Exec, Path and Icon entries
-envsubst < StreamDeckLauncher.desktop > "$desktop_file_target"
+# Replace the placeholder path in the .desktop file with the actual install directory
+sed_expr="s|\\\$HOME/Stream-Deck|$install_dir|g"
+sed "$sed_expr" StreamDeckLauncher.desktop > "$desktop_file_target"
 
 chmod +x "$desktop_file_target"
 

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -42,11 +42,10 @@ describe('install.sh', () => {
 
     const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
     const content = fs.readFileSync(desktopPath, 'utf8');
-    const expanded = content.replace(/\$HOME/g, tmpHome);
 
-    expect(expanded).toContain(`Exec=${tmpHome}/Stream-Deck/StreamDeckLauncher.sh`);
-    expect(expanded).toContain(`Path=${tmpHome}/Stream-Deck`);
-    expect(expanded).toContain(`Icon=${tmpHome}/Stream-Deck/icons/netflix.png`);
+    expect(content).toContain(`Exec=${repoRoot}/StreamDeckLauncher.sh`);
+    expect(content).toContain(`Path=${repoRoot}`);
+    expect(content).toContain(`Icon=${repoRoot}/icons/netflix.png`);
 
     fs.accessSync(desktopPath, fs.constants.X_OK);
 


### PR DESCRIPTION
## Summary
- update `install.sh` to record the repo path and use `sed` to update the desktop file
- adjust the install script tests for the new path logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e7f6b348832f947a912403039281