### PR TITLE
Fix installer working directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+# Always operate from the directory containing this script so relative paths
+# work regardless of where the installer was launched from.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
 echo "Stream Deck Launcher Installer (Steam Deck Safe Version)"
 echo "--------------------------------------------"
 


### PR DESCRIPTION
## Summary
- force installer to run from its own directory

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844ed2871a0832fa3d29715e1777faa