### PR TITLE
Document and enforce Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ CHROMIUM_CMD="/usr/bin/chromium --ozone-platform=wayland" ./StreamDeckLauncher.s
 
 ## Development
 
-This project uses **Node.js 18** as specified in `.nvmrc` and the CI workflow.
+This project requires **Node.js 18**, as specified in `.nvmrc` and the CI workflow.
 
 Install Node.js dependencies and run the test and lint tasks:
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint .",
     "build": "electron-builder -mwl"
   },
+  "engines": {
+    "node": "18.x"
+  },
   "author": "N47H4NI3L <74298967+n47h4ni3l@users.noreply.github.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- specify Node.js version in `package.json`
- clarify Node 18 requirement in development docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844f0113a44832f9631f5fb64f3282b