### PR TITLE
Fix installer path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ echo "f39e1189e898c3f494f21561f2d755bbff384e34faacc1eb87e344cfcc29a6a8  /tmp/str
 bash /tmp/stream-deck-install.sh
 ```
 
+The installer clones the repository to `$HOME/Stream-Deck` if it isn't already present.
+
 The checksum check ensures the script has not been tampered with before it
 installs dependencies and launches the Stream Deck Launcher.
 ---


### PR DESCRIPTION
## Summary
- ensure installer detects repo from invocation directory
- clone repo to `$HOME/Stream-Deck` when needed
- normalize line endings in launcher script
- clarify README install instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844faa5ac20832fb60478ff7bc208b0