### PR TITLE
Fix Node.js install prompt

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -18,7 +18,7 @@ if command -v npx >/dev/null 2>&1; then
 elif command -v flatpak >/dev/null 2>&1; then
     NPX_CMD="flatpak run --command=npx org.nodejs.Node"
 else
-    echo "npx not found – install Node.js." >&2
+    echo "npx not found - install Node.js." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- use a hyphen instead of an en dash in `StreamDeckLauncher.sh`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684505cd08b4832f82a440308ef7a97c