### PR TITLE
Update Wayland session detection

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -23,7 +23,7 @@ else
 fi
 
 # Detect Wayland or X11
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
   "$NPX_CMD" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
 else


### PR DESCRIPTION
## Summary
- handle Wayland sessions when `WAYLAND_DISPLAY` is present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684505d7a23c832fa96dd0fb57aaed20