### PR TITLE
Add launcher script test

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -14,9 +14,9 @@ cd "$(dirname "$0")"
 
 # Determine how to run npx
 if command -v npx >/dev/null 2>&1; then
-    NPX_CMD="npx"
+    NPX_CMD=(npx)
 elif command -v flatpak >/dev/null 2>&1; then
-    NPX_CMD="flatpak run --command=npx org.nodejs.Node"
+    NPX_CMD=(flatpak run --command=npx org.nodejs.Node)
 else
     echo "npx not found - install Node.js." >&2
     exit 1
@@ -25,8 +25,8 @@ fi
 # Detect Wayland or X11
 if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
-  "$NPX_CMD" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
+  "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
 else
   echo "Detected X11 session. Launching without Wayland flags..."
-  "$NPX_CMD" electron .
+  "${NPX_CMD[@]}" electron .
 fi

--- a/tests/launcherScript.test.js
+++ b/tests/launcherScript.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const script = path.join(repoRoot, 'StreamDeckLauncher.sh');
+
+function makeStub(dir, name, content) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+describe('StreamDeckLauncher.sh', () => {
+  let tmpDir;
+  let binDir;
+  let logFile;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-test-'));
+    binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+    logFile = path.join(tmpDir, 'log');
+
+    makeStub(binDir, 'flatpak', `#!/usr/bin/env bash\necho \"flatpak $@\" >> \"$STUB_LOG\"\nexit 0\n`);
+    // npx stub (not on PATH) to ensure it's not used when absent
+    makeStub(tmpDir, 'npx', '#!/usr/bin/env bash\nexit 1\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const runScript = (env) => {
+    return spawnSync('bash', [script], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ...env,
+        STUB_LOG: logFile,
+        PATH: `${binDir}:/usr/bin`,
+      },
+      encoding: 'utf8'
+    });
+  };
+
+  test.each([
+    ['wayland', { XDG_SESSION_TYPE: 'wayland' }, 'flatpak run --command=npx org.nodejs.Node electron . --enable-features=UseOzonePlatform --ozone-platform=wayland'],
+    ['x11', {}, 'flatpak run --command=npx org.nodejs.Node electron .']
+  ])('falls back to flatpak when npx absent on %s', (_, extraEnv, expected) => {
+    const result = runScript(extraEnv);
+    expect(result.status).toBe(0);
+    const log = fs.readFileSync(logFile, 'utf8').trim();
+    expect(log).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- improve quoting in `StreamDeckLauncher.sh`
- add test to run launcher script via Jest

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684508b0d000832f82a60077ca0f63e0