### PR TITLE
Fix launcher detection and add tests

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -23,10 +23,14 @@ else
 fi
 
 # Detect Wayland or X11
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+# Detect session type and launch Electron accordingly
+if [ -n "${WAYLAND_DISPLAY-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
-  "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
+  "${NPX_CMD[@]}" electron . --ozone-platform=wayland
+elif [ -n "${DISPLAY-}" ]; then
+  echo "Detected X11 session. Launching with X11 fallback flags..."
+  "${NPX_CMD[@]}" electron .
 else
-  echo "Detected X11 session. Launching without Wayland flags..."
+  echo "Unknown display server. Defaulting to X11 fallback..."
   "${NPX_CMD[@]}" electron .
 fi

--- a/tests/launcherScript.test.js
+++ b/tests/launcherScript.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+describe('StreamDeckLauncher.sh', () => {
+  test('uses npx when available with Wayland', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-'));
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+    const outFile = path.join(tmpDir, 'out');
+
+    const npxStub = path.join(binDir, 'npx');
+    fs.writeFileSync(npxStub, '#!/usr/bin/env bash\n' +
+      'echo "$@" > "$STUB_OUTPUT"\n');
+    fs.chmodSync(npxStub, 0o755);
+
+    const flatpakStub = path.join(binDir, 'flatpak');
+    fs.writeFileSync(flatpakStub, '#!/usr/bin/env bash\nexit 0\n');
+    fs.chmodSync(flatpakStub, 0o755);
+
+    const env = {
+      ...process.env,
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HOME: tmpDir,
+      WAYLAND_DISPLAY: '1',
+      STUB_OUTPUT: outFile
+    };
+
+    const result = spawnSync('bash', ['StreamDeckLauncher.sh'], {
+      cwd: repoRoot,
+      env,
+      encoding: 'utf8'
+    });
+
+    expect(result.status).toBe(0);
+    const output = fs.readFileSync(outFile, 'utf8');
+    expect(output).toContain('electron');
+    expect(output).toContain('--ozone-platform=wayland');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('uses flatpak fallback when npx unavailable (X11)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-'));
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+    const outFile = path.join(tmpDir, 'out');
+
+    const flatpakStub = path.join(binDir, 'flatpak');
+    fs.writeFileSync(flatpakStub, '#!/usr/bin/env bash\n' +
+      'echo "$@" > "$STUB_OUTPUT"\n');
+    fs.chmodSync(flatpakStub, 0o755);
+
+    const env = {
+      ...process.env,
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HOME: tmpDir,
+      DISPLAY: ':0',
+      STUB_OUTPUT: outFile
+    };
+
+    const result = spawnSync('bash', ['StreamDeckLauncher.sh'], {
+      cwd: repoRoot,
+      env,
+      encoding: 'utf8'
+    });
+
+    expect(result.status).toBe(0);
+    const output = fs.readFileSync(outFile, 'utf8');
+    expect(output).toContain('run --command=npx org.nodejs.Node');
+    expect(output).toContain('electron');
+    expect(output).not.toContain('--ozone-platform=wayland');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- handle `WAYLAND_DISPLAY` vs `DISPLAY` in StreamDeckLauncher.sh
- keep `npx` command as array and launch Electron with correct flags
- add Jest tests that spawn the launcher script to verify `npx`/`flatpak` usage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684507d470b4832f8c39b4eae1856dc4