### PR TITLE
Improve launcher detection and add script tests

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -23,10 +23,16 @@ else
 fi
 
 # Detect Wayland or X11
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+if [ -n "${WAYLAND_DISPLAY:-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
-  "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
-else
+  "${NPX_CMD[@]}" electron . --ozone-platform=wayland
+elif [ -n "${DISPLAY:-}" ]; then
   echo "Detected X11 session. Launching without Wayland flags..."
+  "${NPX_CMD[@]}" electron .
+elif [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
+  echo "Detected Wayland session via XDG_SESSION_TYPE. Launching with Wayland flags..."
+  "${NPX_CMD[@]}" electron . --ozone-platform=wayland
+else
+  echo "Unknown session type. Launching without Wayland flags..."
   "${NPX_CMD[@]}" electron .
 fi

--- a/install.sh
+++ b/install.sh
@@ -114,8 +114,8 @@ desktop_file_target="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 echo "Copying StreamDeckLauncher.desktop to $desktop_file_target..."
 mkdir -p "$(dirname "$desktop_file_target")"
 # Replace the placeholder path in the .desktop file with the actual install directory
-sed_expr="s|\\\$HOME/Stream-Deck|$install_dir|g"
-sed "$sed_expr" StreamDeckLauncher.desktop > "$desktop_file_target"
+safe_dir=${install_dir//|/\\|}
+sed -e "s|\$HOME/Stream-Deck|$safe_dir|g" StreamDeckLauncher.desktop > "$desktop_file_target"
 
 chmod +x "$desktop_file_target"
 

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -33,22 +33,23 @@ describe('install.sh', () => {
     fs.chmodSync(launcher, 0o755);
 
     const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}` };
-    const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+    let result;
+    try {
+      result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+      expect(result.status).toBe(0);
 
-    fs.writeFileSync(launcher, origLauncher);
-    fs.chmodSync(launcher, origMode);
+      const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
+      const content = fs.readFileSync(desktopPath, 'utf8');
 
-    expect(result.status).toBe(0);
+      expect(content).toContain(`Exec=${repoRoot}/StreamDeckLauncher.sh`);
+      expect(content).toContain(`Path=${repoRoot}`);
+      expect(content).toContain(`Icon=${repoRoot}/icons/netflix.png`);
 
-    const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
-    const content = fs.readFileSync(desktopPath, 'utf8');
-
-    expect(content).toContain(`Exec=${repoRoot}/StreamDeckLauncher.sh`);
-    expect(content).toContain(`Path=${repoRoot}`);
-    expect(content).toContain(`Icon=${repoRoot}/icons/netflix.png`);
-
-    fs.accessSync(desktopPath, fs.constants.X_OK);
-
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.accessSync(desktopPath, fs.constants.X_OK);
+    } finally {
+      fs.writeFileSync(launcher, origLauncher);
+      fs.chmodSync(launcher, origMode);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/launcherScript.test.js
+++ b/tests/launcherScript.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+describe('StreamDeckLauncher.sh', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+
+  const makeStub = (dir, name, content) => {
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, content);
+    fs.chmodSync(file, 0o755);
+  };
+
+  test('uses npx under Wayland', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-test-'));
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const cmdFile = path.join(tmpDir, 'cmd');
+    makeStub(binDir, 'npx', `#!/usr/bin/env bash\necho "$@" > "${cmdFile}"\n`);
+
+    const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}`, WAYLAND_DISPLAY: 'wayland-0' };
+    spawnSync('bash', ['StreamDeckLauncher.sh'], { cwd: repoRoot, env });
+
+    const cmd = fs.readFileSync(cmdFile, 'utf8').trim();
+    expect(cmd).toBe('electron . --ozone-platform=wayland');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('falls back to flatpak run when npx missing', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-test-'));
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const cmdFile = path.join(tmpDir, 'cmd');
+    makeStub(binDir, 'flatpak', `#!/usr/bin/env bash\necho "$@" > "${cmdFile}"\n`);
+
+    const env = { ...process.env, PATH: `${binDir}:/usr/bin`, DISPLAY: ':0' };
+    spawnSync('bash', ['StreamDeckLauncher.sh'], { cwd: repoRoot, env });
+
+    const cmd = fs.readFileSync(cmdFile, 'utf8').trim();
+    expect(cmd).toBe('run --command=npx org.nodejs.Node electron .');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- improve Wayland/X11 detection in `StreamDeckLauncher.sh`
- escape pipes in install path before sed replacement
- add cleanup to `installScript.test.js`
- add tests for launcher script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450e8f886c832f847c2eab3a5d3aca