### PR TITLE
Improve saveUsage error handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,7 +60,11 @@ function loadUsage() {
 
 // Save usage data
 function saveUsage() {
-  fs.writeFileSync(usageFile, JSON.stringify(usageData));
+  try {
+    fs.writeFileSync(usageFile, JSON.stringify(usageData));
+  } catch (err) {
+    console.warn('Unable to save usage data:', err);
+  }
 }
 
 // Launch a service URL in Chromium and track usage

--- a/tests/loadSaveUsage.test.js
+++ b/tests/loadSaveUsage.test.js
@@ -44,4 +44,18 @@ describe('loadUsage and saveUsage', () => {
     const data = JSON.parse(fs.readFileSync(usageFile));
     expect(data['Hulu']).toBe(3);
   });
+
+  test('logs warning if saving usage fails', () => {
+    const err = new Error('fail');
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const orig = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw err;
+    });
+
+    expect(() => saveUsage()).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+
+    orig.mockRestore();
+    warn.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- handle failures when writing usage data
- test saveUsage warning when write fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a597e074832fb64945fa433ab652