### PR TITLE
Add node version check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ install_dir="$(pwd)"
 chmod +x "$install_dir/StreamDeckLauncher.sh"
 
 # Ensure required commands exist
-for cmd in flatpak git curl sha256sum; do
+for cmd in flatpak git curl sha256sum node; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required but not installed. Aborting." >&2
     exit 1
@@ -54,11 +54,17 @@ fi
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
 
-# Install required Node.js version
+# Ensure Node.js version matches .nvmrc
 required_node="$(cat "$install_dir/.nvmrc")"
-if ! node -v | grep -q "v$required_node"; then
-  echo "Installing Node.js $required_node with Volta..."
-  volta install node@"$required_node"
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js $required_node is required but not installed. Aborting." >&2
+  exit 1
+fi
+current_node="$(node --version)"
+current_major="$(echo "$current_node" | sed -E 's/^v([0-9]+).*$/\1/')"
+if [ "$current_major" != "$required_node" ]; then
+  echo "Detected Node.js $current_node but version $required_node is required. Aborting." >&2
+  exit 1
 fi
 
 # Install npm dependencies

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -25,6 +25,7 @@ describe('install.sh', () => {
     makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
     makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
     makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
 
     const launcher = path.join(repoRoot, 'StreamDeckLauncher.sh');
     const origLauncher = fs.readFileSync(launcher);


### PR DESCRIPTION
## Summary
- ensure node is in command pre-checks
- verify `node --version` matches `.nvmrc` and abort otherwise
- update install script unit test for new node requirement

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845a598db10832fa98c98c65e25fa21