### PR TITLE
Fix npx prompt and auto install dependencies

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -11,12 +11,17 @@ export PATH="$VOLTA_HOME/bin:$PATH"
 # Set working directory to script location
 cd "$(dirname "$0")"
 
+# Ensure npm dependencies are installed
+if [ ! -d node_modules/electron ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
 
 # Determine how to run npx
 if command -v npx >/dev/null 2>&1; then
-    NPX_CMD=(npx)
+    NPX_CMD=(npx --yes)
 elif command -v flatpak >/dev/null 2>&1; then
-    NPX_CMD=(flatpak run --command=npx org.nodejs.Node)
+    NPX_CMD=(flatpak run --command=npx org.nodejs.Node --yes)
 else
     echo "npx not found - install Node.js." >&2
     exit 1


### PR DESCRIPTION
## Summary
- check for missing `node_modules/electron` and run `npm install`
- run `npx` with `--yes` so Electron installs without prompting

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845aabab250832fadfc601026af11db