### PR TITLE
Add basic logging support

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -11,6 +11,11 @@ export PATH="$VOLTA_HOME/bin:$PATH"
 # Set working directory to script location
 cd "$(dirname "$0")"
 
+# Set up logging
+LOG_FILE="$PWD/log.txt"
+exec > >(tee -a "$LOG_FILE") 2>&1
+set -x
+
 # Ensure npm dependencies are installed
 if [ ! -d node_modules/electron ]; then
     echo "Installing npm dependencies..."


### PR DESCRIPTION
## Summary
- log application errors to `log.txt`
- route all shell output to `log.txt` for easier debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845b14bd09c832f99ed10dced1ec330