### PR TITLE
Fix uninstall.sh Exec path parsing

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,7 +8,7 @@ install_dir=""
 
 if [ -f "$desktop_file" ]; then
   # Extract install directory from Exec line in desktop file
-  exec_path=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d'=' -f2)
+  exec_path=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d'=' -f2 | sed 's/^\"//; s/\"$//')
   install_dir="$(dirname "$exec_path")"
   rm -f "$desktop_file"
   echo "Removed $desktop_file"


### PR DESCRIPTION
## Summary
- strip surrounding quotes from the `Exec` line in uninstall script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bf81eb84832faa9879cd914b1acc