### PR TITLE
Improve launcher logging and exit handling

### DIFF
--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -32,7 +32,12 @@ else
     exit 1
 fi
 
+# Log versions for troubleshooting
+node --version
+"${NPX_CMD[@]}" --version
+
 # Detect Wayland or X11
+set +e
 if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
   "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
@@ -40,3 +45,10 @@ else
   echo "Detected X11 session. Launching without Wayland flags..."
   "${NPX_CMD[@]}" electron .
 fi
+exit_code=$?
+set -e
+echo "Electron exited with code $exit_code"
+if [ "$exit_code" -ne 0 ]; then
+  echo "An error occurred launching Electron. See $LOG_FILE for details."
+fi
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- log `node` and `npx` versions when launching
- run Electron command with `set +e` and log exit code

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845bf8f10a4832f815bbd2d823920d6