### PR TITLE
Fix uninstall exec path extraction

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,10 +7,8 @@ desktop_file="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 install_dir=""
 
 if [ -f "$desktop_file" ]; then
-  # Extract install directory from Exec line in desktop file
-  exec_path=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d'=' -f2-)
-  exec_path="${exec_path%\"}"
-  exec_path="${exec_path#\"}"
+  # Extract install directory from Exec line, removing quotes and ignoring arguments
+  exec_path=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d '=' -f2- | sed -E 's/^"([^"]+)"(.*)$/\1/')
   install_dir="$(dirname "$exec_path")"
   rm -f "$desktop_file"
   echo "Removed $desktop_file"


### PR DESCRIPTION
## Summary
- simplify uninstall `Exec=` parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c49445b4832fbc2010f2f9503ea3