### PR TITLE
Fix LD_PRELOAD issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ All launcher output is appended to `log.txt` in the installation directory. Run 
 
 Wayland mode automatically activates when `XDG_SESSION_TYPE=wayland` or `WAYLAND_DISPLAY` is set.
 
+`LD_PRELOAD` is cleared automatically to avoid conflicts with Steam's overlay.
+
 ---
 
 ## Community

--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -11,6 +11,9 @@ export PATH="$VOLTA_HOME/bin:$PATH"
 # Set working directory to script location
 cd "$(dirname "$0")"
 
+# Prevent Steam’s 32-bit overlay from breaking Electron
+unset LD_PRELOAD
+
 # Set up logging
 LOG_FILE="$PWD/log.txt"
 exec > >(tee -a "$LOG_FILE") 2>&1


### PR DESCRIPTION
## Summary
- prevent Steam's overlay from breaking Electron by clearing `LD_PRELOAD`
- document the automatic `LD_PRELOAD` handling in the troubleshooting section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684646811238832fb5bf75d0e80c3a53