### PR TITLE
Fix install script command check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ install_dir="$(pwd)"
 chmod +x "$install_dir/StreamDeckLauncher.sh"
 
 # Ensure required commands exist
-for cmd in flatpak git curl sha256sum node; do
+for cmd in flatpak git curl node; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required but not installed. Aborting." >&2
     exit 1

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -21,7 +21,6 @@ describe('install.sh', () => {
 
     makeStub('flatpak', '#!/usr/bin/env bash\nexit 0\n');
     makeStub('curl', '#!/usr/bin/env bash\nwhile [ "$1" != "" ]; do if [ "$1" = "-o" ]; then touch "$2"; shift 2; else shift; fi; done\nexit 0\n');
-    makeStub('sha256sum', '#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n');
     makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
     makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
     makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');


### PR DESCRIPTION
## Summary
- drop `sha256sum` from the command list in `install.sh`
- adjust unit test to match updated command check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846468e6650832fb1626e3426764753