### PR TITLE
Implement sandbox flag support and improve checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Example:
 CHROMIUM_CMD="/usr/bin/chromium --ozone-platform=wayland" ./StreamDeckLauncher.sh
 ```
 
+### Extra Electron Flags
+Set `ELECTRON_EXTRA_FLAGS` to append additional flags when launching Electron. This is useful for options like `--no-sandbox` that some SteamOS setups require.
+
+Example:
+```bash
+ELECTRON_EXTRA_FLAGS="--no-sandbox" ./StreamDeckLauncher.sh
+```
+
 ---
 
 ## Development
@@ -73,6 +81,8 @@ All launcher output is appended to `log.txt` in the installation directory. Run 
 Wayland mode automatically activates when `XDG_SESSION_TYPE=wayland` or `WAYLAND_DISPLAY` is set.
 
 `LD_PRELOAD` is cleared automatically to avoid conflicts with Steam's overlay.
+
+If Electron or Chromium refuses to start due to sandbox errors on SteamOS, pass the `--no-sandbox` flag using `ELECTRON_EXTRA_FLAGS` or by including it in `CHROMIUM_CMD`.
 
 ---
 

--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -39,18 +39,25 @@ fi
 node --version
 "${NPX_CMD[@]}" --version
 
+# Parse optional extra Electron flags
+EXTRA_ELECTRON_FLAGS=()
+if [ -n "${ELECTRON_EXTRA_FLAGS:-}" ]; then
+  # shellcheck disable=SC2206
+  EXTRA_ELECTRON_FLAGS=(${ELECTRON_EXTRA_FLAGS})
+fi
+
 # Detect Wayland or X11
 set +e
 if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
   echo "Detected Wayland session. Launching with Wayland flags..."
   export ELECTRON_ENABLE_LOGGING=1
   export ELECTRON_ENABLE_STACK_DUMPING=1
-  ELECTRON_ENABLE_LOGGING=1 ELECTRON_ENABLE_STACK_DUMPING=1 "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland
+  ELECTRON_ENABLE_LOGGING=1 ELECTRON_ENABLE_STACK_DUMPING=1 "${NPX_CMD[@]}" electron . --enable-features=UseOzonePlatform --ozone-platform=wayland "${EXTRA_ELECTRON_FLAGS[@]}"
 else
   echo "Detected X11 session. Launching without Wayland flags..."
   export ELECTRON_ENABLE_LOGGING=1
   export ELECTRON_ENABLE_STACK_DUMPING=1
-  ELECTRON_ENABLE_LOGGING=1 ELECTRON_ENABLE_STACK_DUMPING=1 "${NPX_CMD[@]}" electron .
+  ELECTRON_ENABLE_LOGGING=1 ELECTRON_ENABLE_STACK_DUMPING=1 "${NPX_CMD[@]}" electron . "${EXTRA_ELECTRON_FLAGS[@]}"
 fi
 exit_code=$?
 set -e

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ install_dir="$(pwd)"
 chmod +x "$install_dir/StreamDeckLauncher.sh"
 
 # Ensure required commands exist
-for cmd in flatpak git curl node; do
+for cmd in flatpak git curl node npm npx; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required but not installed. Aborting." >&2
     exit 1

--- a/tests/electronFlags.test.js
+++ b/tests/electronFlags.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+describe('StreamDeckLauncher.sh', () => {
+  test('honors ELECTRON_EXTRA_FLAGS', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-flag-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const outputFile = path.join(tmpDir, 'npx_args');
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('npx', `#!/usr/bin/env bash\necho \"$@\" > \"${outputFile}\"\n`);
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+
+    const electronDir = path.join(repoRoot, 'node_modules', 'electron');
+    fs.mkdirSync(electronDir, { recursive: true });
+
+    const env = {
+      ...process.env,
+      HOME: tmpHome,
+      PATH: `${binDir}:${process.env.PATH}`,
+      ELECTRON_EXTRA_FLAGS: '--no-sandbox',
+      XDG_SESSION_TYPE: 'wayland'
+    };
+    const result = spawnSync('bash', ['./StreamDeckLauncher.sh'], { cwd: repoRoot, env });
+
+    expect(result.status).toBe(0);
+    const args = fs.readFileSync(outputFile, 'utf8').trim();
+    expect(args.endsWith('--no-sandbox')).toBe(true);
+
+    fs.rmSync(electronDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- document ELECTRON_EXTRA_FLAGS and --no-sandbox troubleshooting
- check for npm and npx in install.sh
- allow extra Electron flags in StreamDeckLauncher.sh
- test handling of ELECTRON_EXTRA_FLAGS

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Stream-Deck/node_modules/electron/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68465643b8dc832fa8cce9629bb0dca1