### PR TITLE
Update root sandbox handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Example:
 ELECTRON_EXTRA_FLAGS="--no-sandbox" ./StreamDeckLauncher.sh
 ```
 
+The launcher automatically adds `--no-sandbox` when executed as the `root` user.
+
 ---
 
 ## Development
@@ -82,7 +84,7 @@ Wayland mode automatically activates when `XDG_SESSION_TYPE=wayland` or `WAYLAND
 
 `LD_PRELOAD` is cleared automatically to avoid conflicts with Steam's overlay.
 
-If Electron or Chromium refuses to start due to sandbox errors on SteamOS, pass the `--no-sandbox` flag using `ELECTRON_EXTRA_FLAGS` or by including it in `CHROMIUM_CMD`.
+The launcher adds `--no-sandbox` when run as `root`. If Electron or Chromium still refuses to start, pass additional flags using `ELECTRON_EXTRA_FLAGS` or include them in `CHROMIUM_CMD`.
 
 ---
 

--- a/StreamDeckLauncher.sh
+++ b/StreamDeckLauncher.sh
@@ -46,6 +46,14 @@ if [ -n "${ELECTRON_EXTRA_FLAGS:-}" ]; then
   EXTRA_ELECTRON_FLAGS=(${ELECTRON_EXTRA_FLAGS})
 fi
 
+# Automatically disable the sandbox when running as root unless already set
+if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+  case " ${EXTRA_ELECTRON_FLAGS[*]} " in
+    *'--no-sandbox'*) ;;
+    *) EXTRA_ELECTRON_FLAGS+=("--no-sandbox") ;;
+  esac
+fi
+
 # Detect Wayland or X11
 set +e
 if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then

--- a/tests/electronFlags.test.js
+++ b/tests/electronFlags.test.js
@@ -48,4 +48,48 @@ describe('StreamDeckLauncher.sh', () => {
     }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  test('adds --no-sandbox automatically when run as root', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-root-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const outputFile = path.join(tmpDir, 'npx_args');
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('npx', `#!/usr/bin/env bash\necho "$@" > "${outputFile}"\n`);
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+
+    const electronDir = path.join(repoRoot, 'node_modules', 'electron');
+    const existed = fs.existsSync(electronDir);
+    if (!existed) {
+      fs.mkdirSync(electronDir, { recursive: true });
+    }
+
+    const env = {
+      ...process.env,
+      HOME: tmpHome,
+      PATH: `${binDir}:${process.env.PATH}`,
+      XDG_SESSION_TYPE: 'wayland'
+    };
+    const result = spawnSync('bash', ['./StreamDeckLauncher.sh'], { cwd: repoRoot, env });
+
+    expect(result.status).toBe(0);
+    const args = fs.readFileSync(outputFile, 'utf8').trim();
+    expect(args.endsWith('--no-sandbox')).toBe(true);
+
+    if (!existed) {
+      fs.rmSync(electronDir, { recursive: true, force: true });
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
- mention automatic `--no-sandbox` for root in docs
- add automatic flag to launcher script
- test the root behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846627946cc832f9ffb85128b679991