### PR TITLE
feat: persist CHROMIUM_CMD in desktop file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Example:
 CHROMIUM_CMD="/usr/bin/chromium --ozone-platform=wayland" ./StreamDeckLauncher.sh
 ```
 
+To launch each service in a console-style window you can include kiosk or full-screen
+flags in `CHROMIUM_CMD`:
+
+```bash
+CHROMIUM_CMD="flatpak run io.github.ungoogled_software.ungoogled_chromium --kiosk" ./StreamDeckLauncher.sh
+```
+If you run the installer with `CHROMIUM_CMD` set, the desktop file will
+automatically include the same value so Gaming Mode launches Chromium in kiosk
+mode. You can still edit
+`~/.local/share/applications/StreamDeckLauncher.desktop` later if you want to
+change the command.
+
 ### Extra Electron Flags
 Set `ELECTRON_EXTRA_FLAGS` to append additional flags when launching Electron. This is useful for options like `--no-sandbox` that some SteamOS setups require.
 

--- a/install.sh
+++ b/install.sh
@@ -74,13 +74,20 @@ npm install
 desktop_dir="$HOME/.local/share/applications"
 mkdir -p "$desktop_dir"
 desktop_file="$desktop_dir/StreamDeckLauncher.desktop"
+
+if [ -n "${CHROMIUM_CMD:-}" ]; then
+  exec_line="env CHROMIUM_CMD=\"${CHROMIUM_CMD}\" \"${install_dir}/StreamDeckLauncher.sh\""
+else
+  exec_line="\"${install_dir}/StreamDeckLauncher.sh\""
+fi
+
 cat > "$desktop_file" <<DESK
 [Desktop Entry]
 Version=1.0
 Type=Application
 Name=Stream Deck Launcher
 Comment=Unified streaming launcher for Steam Deck
-Exec="${install_dir}/StreamDeckLauncher.sh"
+Exec=${exec_line}
 Path="${install_dir}"
 Icon="${install_dir}/build/icon.png"
 Terminal=false

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -51,4 +51,50 @@ describe('install.sh', () => {
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  test('persists CHROMIUM_CMD when provided', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-test-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('flatpak', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('curl', '#!/usr/bin/env bash\nwhile [ "$1" != "" ]; do if [ "$1" = "-o" ]; then touch "$2"; shift 2; else shift; fi; done\nexit 0\n');
+    makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+
+    const launcher = path.join(repoRoot, 'StreamDeckLauncher.sh');
+    const origLauncher = fs.readFileSync(launcher);
+    const origMode = fs.statSync(launcher).mode & 0o777;
+    fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
+    fs.chmodSync(launcher, 0o755);
+
+    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: 'my-chrome --foo' };
+    const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+
+    fs.writeFileSync(launcher, origLauncher);
+    fs.chmodSync(launcher, origMode);
+
+    expect(result.status).toBe(0);
+
+    const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
+    const content = fs.readFileSync(desktopPath, 'utf8');
+
+    expect(content).toContain(`Exec=env CHROMIUM_CMD="my-chrome --foo" "${repoRoot}/StreamDeckLauncher.sh"`);
+
+    fs.accessSync(desktopPath, fs.constants.X_OK);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
- persist `CHROMIUM_CMD` in the desktop file when installing
- document automatic kiosk-mode setup in the README
- test that the installer writes the env var

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684666ac2a80832fad643ae59fdfe3df