### PR TITLE
Improve uninstall path parsing

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,8 +7,12 @@ desktop_file="$HOME/.local/share/applications/StreamDeckLauncher.desktop"
 install_dir=""
 
 if [ -f "$desktop_file" ]; then
-  # Extract install directory from Exec line, removing quotes and ignoring arguments
-  exec_path=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d '=' -f2- | sed -E 's/^"([^"]+)"(.*)$/\1/')
+  # Extract install directory from Exec line, handling optional env prefix and quoted paths
+  exec_line=$(grep -E '^Exec=' "$desktop_file" | head -n1 | cut -d '=' -f2-)
+  exec_path=$(echo "$exec_line" | grep -oE '"[^"]*StreamDeckLauncher\.sh"' | head -n1 | tr -d '"' || true)
+  if [ -z "$exec_path" ]; then
+    exec_path=$(echo "$exec_line" | grep -oE '[^ ]*StreamDeckLauncher\.sh' | head -n1 || true)
+  fi
   install_dir="$(dirname "$exec_path")"
   rm -f "$desktop_file"
   echo "Removed $desktop_file"


### PR DESCRIPTION
## Summary
- robustly parse install path in `uninstall.sh`
- support exec lines with `env` prefix
- add regression test for uninstall script with env prefix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684682e80ccc832f95c1413426fc89eb