### PR TITLE
Fix CHROMIUM_CMD quoting in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ mkdir -p "$desktop_dir"
 desktop_file="$desktop_dir/StreamDeckLauncher.desktop"
 
 if [ -n "${CHROMIUM_CMD:-}" ]; then
-  exec_line="env CHROMIUM_CMD=\"${CHROMIUM_CMD}\" \"${install_dir}/StreamDeckLauncher.sh\""
+  exec_line="env CHROMIUM_CMD=${CHROMIUM_CMD@Q} \"${install_dir}/StreamDeckLauncher.sh\""
 else
   exec_line="\"${install_dir}/StreamDeckLauncher.sh\""
 fi

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -80,7 +80,8 @@ describe('install.sh', () => {
     fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
     fs.chmodSync(launcher, 0o755);
 
-    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: 'my-chrome --foo' };
+    const chromiumCmd = '/usr/bin/chromium --kiosk --flag="foo bar"';
+    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: chromiumCmd };
     const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
 
     fs.writeFileSync(launcher, origLauncher);
@@ -91,7 +92,7 @@ describe('install.sh', () => {
     const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
     const content = fs.readFileSync(desktopPath, 'utf8');
 
-    expect(content).toContain(`Exec=env CHROMIUM_CMD="my-chrome --foo" "${repoRoot}/StreamDeckLauncher.sh"`);
+    expect(content).toContain(`Exec=env CHROMIUM_CMD='${chromiumCmd.replace(/'/g, "'\\''")}' "${repoRoot}/StreamDeckLauncher.sh"`);
 
     fs.accessSync(desktopPath, fs.constants.X_OK);
 


### PR DESCRIPTION
## Summary
- properly quote `$CHROMIUM_CMD` when creating the Exec line
- test launcher install with command containing spaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ce33922c832fab59d41224e702f4