### PR TITLE
Handle quoted CHROMIUM_CMD

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, powerSaveBlocker } = require('electron');
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const shellQuote = require('shell-quote');
 
 // Log file path
 const logFile = path.join(__dirname, 'log.txt');
@@ -19,7 +20,7 @@ function logError(msg, err = '') {
 // Flatpak command for Ungoogled Chromium
 const defaultChromiumCommand = ['flatpak', 'run', 'io.github.ungoogled_software.ungoogled_chromium'];
 const chromiumCommand = process.env.CHROMIUM_CMD
-  ? process.env.CHROMIUM_CMD.split(/\s+/)
+  ? shellQuote.parse(process.env.CHROMIUM_CMD)
   : defaultChromiumCommand;
 
 // No-sleep blocker

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,17 @@
       "name": "streamdeck-launcher",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.8.3"
+      },
       "devDependencies": {
         "electron": "^29.4.0",
         "electron-builder": "^24.6.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7238,6 +7244,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "electron-builder -l"
   },
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "build": {
     "linux": {
@@ -19,6 +19,9 @@
   },
   "author": "N47H4NI3L <74298967+n47h4ni3l@users.noreply.github.com>",
   "license": "MIT",
+  "dependencies": {
+    "shell-quote": "^1.8.3"
+  },
   "devDependencies": {
     "jest": "^29.7.0",
     "eslint": "^8.56.0",

--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -58,19 +58,30 @@ describe('launchService', () => {
 
   test('uses CHROMIUM_CMD environment variable when set', () => {
     jest.resetModules();
-    process.env.CHROMIUM_CMD = 'custom-chrome --foo';
+    process.env.CHROMIUM_CMD = '/usr/bin/chromium --flag="foo bar"';
 
     const { spawn } = require('child_process');
     const { launchService: launchWithEnv, services, chromiumCommand } = require('../main');
 
     launchWithEnv('Prime');
 
-    expect(chromiumCommand).toEqual(['custom-chrome', '--foo']);
+    expect(chromiumCommand).toEqual(['/usr/bin/chromium', '--flag=foo bar']);
     expect(spawn).toHaveBeenCalledWith(
       chromiumCommand[0],
       [...chromiumCommand.slice(1), services['Prime']],
       { detached: true, stdio: 'ignore' }
     );
+
+    delete process.env.CHROMIUM_CMD;
+  });
+
+  test('parses CHROMIUM_CMD with quoted path', () => {
+    jest.resetModules();
+    process.env.CHROMIUM_CMD = '"/opt/My Browser/chrome" --incognito';
+
+    const { chromiumCommand } = require('../main');
+
+    expect(chromiumCommand).toEqual(['/opt/My Browser/chrome', '--incognito']);
 
     delete process.env.CHROMIUM_CMD;
   });


### PR DESCRIPTION
## Summary
- add `shell-quote` as a dependency
- parse `CHROMIUM_CMD` using `shell-quote.parse`
- cover quoting cases in `launchService.test.js`
- relax Node engine requirement so CI doesn't fail on newer Node

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68493dd0d03c832f8fe66557c59422a7