### PR TITLE
Add browser existence check to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Run the included `install.sh` script. It clones the repository if needed, instal
 bash install.sh
 ```
 
+The installer verifies that your chosen browser exists. If you select the bundled
+Ungoogled Chromium and it is missing, the Flatpak is installed automatically. A
+custom command must resolve to an executable or the install will abort.
+
 After installation you will find **Stream Deck Launcher** in your application menu. You can also start it directly with `./StreamDeckLauncher.sh`.
 If you later want to change the browser command, edit the `browser_cmd` file in the installation directory.
 ## Adding to Steam

--- a/tests/installScript.test.js
+++ b/tests/installScript.test.js
@@ -80,7 +80,10 @@ describe('install.sh', () => {
     fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
     fs.chmodSync(launcher, 0o755);
 
-    const chromiumCmd = '/usr/bin/chromium --kiosk --flag="foo bar"';
+    const chromiumBin = path.join(binDir, 'chromium');
+    const chromiumCmd = `${chromiumBin} --kiosk --flag="foo bar"`;
+    fs.writeFileSync(chromiumBin, '#!/usr/bin/env bash\nexit 0\n');
+    fs.chmodSync(chromiumBin, 0o755);
     const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: chromiumCmd };
     const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
 
@@ -95,6 +98,145 @@ describe('install.sh', () => {
     expect(content).toContain(`Exec=env CHROMIUM_CMD='${chromiumCmd.replace(/'/g, "'\\''")}' "${repoRoot}/StreamDeckLauncher.sh"`);
 
     fs.accessSync(desktopPath, fs.constants.X_OK);
+
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('installs default browser when missing', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-test-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const flatpakLog = path.join(tmpDir, 'flatpak.log');
+
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('flatpak', `#!/usr/bin/env bash
+if [ "$1" = "info" ]; then
+  exit 1
+fi
+echo "$@" >> '${flatpakLog.replace(/'/g, "'\\''")}'
+exit 0
+`);
+    makeStub('curl', '#!/usr/bin/env bash\nwhile [ "$1" != "" ]; do if [ "$1" = "-o" ]; then touch "$2"; shift 2; else shift; fi; done\nexit 0\n');
+    makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+
+    const launcher = path.join(repoRoot, 'StreamDeckLauncher.sh');
+    const origLauncher = fs.readFileSync(launcher);
+    const origMode = fs.statSync(launcher).mode & 0o777;
+    fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
+    fs.chmodSync(launcher, 0o755);
+
+    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}` };
+    const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+
+    fs.writeFileSync(launcher, origLauncher);
+    fs.chmodSync(launcher, origMode);
+
+    expect(result.status).toBe(0);
+    const log = fs.readFileSync(flatpakLog, 'utf8');
+    expect(log).toContain('install --user --noninteractive -y flathub io.github.ungoogled_software.ungoogled_chromium');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('fails when custom browser is missing', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-test-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('flatpak', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('curl', '#!/usr/bin/env bash\nwhile [ "$1" != "" ]; do if [ "$1" = "-o" ]; then touch "$2"; shift 2; else shift; fi; done\nexit 0\n');
+    makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+
+    const launcher = path.join(repoRoot, 'StreamDeckLauncher.sh');
+    const origLauncher = fs.readFileSync(launcher);
+    const origMode = fs.statSync(launcher).mode & 0o777;
+    fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
+    fs.chmodSync(launcher, 0o755);
+
+    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: 'fakebrowser --flag' };
+    const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+
+    fs.writeFileSync(launcher, origLauncher);
+    fs.chmodSync(launcher, origMode);
+
+    expect(result.status).not.toBe(0);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('handles browser path with spaces', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'install-test-'));
+    const tmpHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(tmpHome);
+
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+
+    const makeStub = (name, content) => {
+      const file = path.join(binDir, name);
+      fs.writeFileSync(file, content);
+      fs.chmodSync(file, 0o755);
+    };
+
+    makeStub('flatpak', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('curl', '#!/usr/bin/env bash\nwhile [ "$1" != "" ]; do if [ "$1" = "-o" ]; then touch "$2"; shift 2; else shift; fi; done\nexit 0\n');
+    makeStub('volta', '#!/usr/bin/env bash\nif [ "$1" = "which" ]; then exit 0; else exit 0; fi\n');
+    makeStub('npm', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('npx', '#!/usr/bin/env bash\nexit 0\n');
+    makeStub('node', '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo v18.0.0; fi\n');
+
+    const spaceDir = path.join(binDir, 'My Browser');
+    fs.mkdirSync(spaceDir);
+    const chromeBin = path.join(spaceDir, 'chrome');
+    fs.writeFileSync(chromeBin, '#!/usr/bin/env bash\nexit 0\n');
+    fs.chmodSync(chromeBin, 0o755);
+
+    const launcher = path.join(repoRoot, 'StreamDeckLauncher.sh');
+    const origLauncher = fs.readFileSync(launcher);
+    const origMode = fs.statSync(launcher).mode & 0o777;
+    fs.writeFileSync(launcher, '#!/usr/bin/env bash\necho launch stub\n');
+    fs.chmodSync(launcher, 0o755);
+
+    const chromiumCmd = `"${chromeBin}" --kiosk`;
+    const env = { ...process.env, HOME: tmpHome, PATH: `${binDir}:${process.env.PATH}`, CHROMIUM_CMD: chromiumCmd };
+    const result = spawnSync('bash', ['install.sh'], { cwd: repoRoot, env });
+
+    fs.writeFileSync(launcher, origLauncher);
+    fs.chmodSync(launcher, origMode);
+
+    expect(result.status).toBe(0);
+
+    const desktopPath = path.join(tmpHome, '.local', 'share', 'applications', 'StreamDeckLauncher.desktop');
+    const content = fs.readFileSync(desktopPath, 'utf8');
+    expect(content).toContain(`Exec=env CHROMIUM_CMD='${chromiumCmd.replace(/'/g, "'\\''")}' "${repoRoot}/StreamDeckLauncher.sh"`);
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- ensure installer verifies chosen browser is installed
- auto-install Ungoogled Chromium Flatpak if missing
- abort when a custom browser command can't be found
- handle browser commands with spaces
- note browser verification in README
- update tests for new installer logic
- rework tests not to write to system directories

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68494b78524c832f8b55d3145c65606e