### PR TITLE
Fix IPC exposure and tidy main process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,6 @@
   "parserOptions": {
     "ecmaVersion": 12
   },
-  "rules": {}
+  "rules": {},
+  "ignorePatterns": ["renderer.js"]
 }

--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  launchService: (url) => ipcRenderer.send('launch-service', url)
+  launchService: (service) => ipcRenderer.send('launch-service', service),
+  getSortedServices: () => ipcRenderer.invoke('get-sorted-services')
 });


### PR DESCRIPTION
## Summary
- remove duplicate window code and unused imports
- load usage data on startup
- expose `getSortedServices` via IPC and preload
- ignore renderer.js in ESLint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68498989e804832fbcfbdbfa0f61f80c