### PR TITLE
Add controller navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Stream Deck Launcher is a simple dashboard for launching streaming services on a
 
 ## Features
 - Large, controller-friendly interface
+- Controller or keyboard navigation between tiles
+- Services open in Chromium kiosk mode for a streamlined experience
 - Remembers how often each service is launched and sorts tiles accordingly
 - Persistent logins for each service
 - Prevents the device from going to sleep while in video playback

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
             transform: scale(1.1);
             box-shadow: 0 0 20px rgba(102, 153, 255, 0.8);
         }
+        .tile.selected {
+            transform: scale(1.1);
+            box-shadow: 0 0 20px rgba(102, 153, 255, 0.8);
+        }
         .tile img {
             max-width: 80%;
             max-height: 80%;
@@ -59,6 +63,69 @@
                 tile.appendChild(img);
                 document.body.appendChild(tile);
             }
+            initNavigation();
+        }
+
+        let tiles = [];
+        let selectedIndex = 0;
+        let columns = 1;
+
+        function updateColumns() {
+            if (!tiles.length) return;
+            const tile = tiles[0];
+            columns = Math.max(1, Math.floor(window.innerWidth / (tile.offsetWidth + 20)));
+        }
+
+        function highlight(index) {
+            if (!tiles.length) return;
+            tiles[selectedIndex].classList.remove('selected');
+            selectedIndex = (index + tiles.length) % tiles.length;
+            tiles[selectedIndex].classList.add('selected');
+        }
+
+        function handleKey(e) {
+            switch (e.key) {
+                case 'ArrowRight':
+                    highlight(selectedIndex + 1);
+                    break;
+                case 'ArrowLeft':
+                    highlight(selectedIndex - 1);
+                    break;
+                case 'ArrowDown':
+                    highlight(selectedIndex + columns);
+                    break;
+                case 'ArrowUp':
+                    highlight(selectedIndex - columns);
+                    break;
+                case 'Enter':
+                case ' ':
+                    tiles[selectedIndex].click();
+                    break;
+            }
+        }
+
+        let prevButtons = [];
+        function pollGamepad() {
+            const [gp] = navigator.getGamepads ? navigator.getGamepads() : [];
+            if (gp) {
+                const map = {12: 'ArrowUp', 13: 'ArrowDown', 14: 'ArrowLeft', 15: 'ArrowRight', 0: 'Enter'};
+                for (const idx in map) {
+                    const pressed = gp.buttons[idx] && gp.buttons[idx].pressed;
+                    if (pressed && !prevButtons[idx]) handleKey({ key: map[idx] });
+                    prevButtons[idx] = pressed;
+                }
+            }
+            requestAnimationFrame(pollGamepad);
+        }
+
+        function initNavigation() {
+            tiles = Array.from(document.querySelectorAll('.tile'));
+            if (!tiles.length) return;
+            updateColumns();
+            tiles[0].classList.add('selected');
+            window.addEventListener('keydown', handleKey);
+            window.addEventListener('resize', updateColumns);
+            requestAnimationFrame(pollGamepad);
         }
 
         loadTiles();

--- a/main.js
+++ b/main.js
@@ -84,9 +84,11 @@ function launchService(serviceName, event) {
   if (!url) return;
 
   try {
+    const args = [...chromiumCommand.slice(1)];
+    if (!args.includes('--kiosk')) args.push('--kiosk');
     const child = spawn(
       chromiumCommand[0],
-      [...chromiumCommand.slice(1), url],
+      [...args, url],
       { detached: true, stdio: 'ignore' }
     );
     child.unref();

--- a/tests/launchService.test.js
+++ b/tests/launchService.test.js
@@ -33,7 +33,7 @@ describe('launchService', () => {
     launchService('Netflix');
     expect(spawn).toHaveBeenCalledWith(
       chromiumCommand[0],
-      [...chromiumCommand.slice(1), services['Netflix']],
+      expect.arrayContaining(['--kiosk', services['Netflix']]),
       { detached: true, stdio: 'ignore' }
     );
   });
@@ -68,7 +68,7 @@ describe('launchService', () => {
     expect(chromiumCommand).toEqual(['/usr/bin/chromium', '--flag=foo bar']);
     expect(spawn).toHaveBeenCalledWith(
       chromiumCommand[0],
-      [...chromiumCommand.slice(1), services['Prime']],
+      expect.arrayContaining(['--flag=foo bar', '--kiosk', services['Prime']]),
       { detached: true, stdio: 'ignore' }
     );
 


### PR DESCRIPTION
## Summary
- support navigating tiles with keyboard and gamepad
- open services with Chromium `--kiosk` flag
- update tests for kiosk launch behavior
- document controller navigation in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68498d539688832f9baf71df8bc01325